### PR TITLE
Use flush_input to flush the input buffer.

### DIFF
--- a/lib/rmodbus/rtu.rb
+++ b/lib/rmodbus/rtu.rb
@@ -17,8 +17,6 @@ module ModBus
   module RTU
     private
 
-    CHUNK_SIZE = 1500
-
     # We have to read specific amounts of numbers of bytes from the network depending on the function code and content
     def read_rtu_response(io)
 	    # Read the slave_id and function code
@@ -47,20 +45,8 @@ module ModBus
     end
 
     def clean_input_buff
-      win_platform = RUBY_PLATFORM.include? "mingw"
-      begin
-        # Read up to CHUNK_SIZE bytes of trash.
-        if win_platform
-          # non-blocking reads are not supported by Windows
-          @io.readpartial(CHUNK_SIZE)
-        else
-          @io.read_nonblock(CHUNK_SIZE)
-        end
-      rescue Errno::EAGAIN
-        # Ignore the fact we couldn't read.
-      rescue Exception => e
-        raise e unless win_platform || e.is_a?(EOFError) # EOFError means we are done
-      end
+      # empty the input buffer
+      @io.flush_input
     end
 
     def send_rtu_pdu(pdu)

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -68,7 +68,7 @@ begin
     it 'should log rec\send bytes' do
       request = "\x3\x0\x1\x0\x1"
       @sp.should_receive(:write).with("\1#{request}\xd5\xca")
-      @sp.should_receive(:read_nonblock).and_return("\xff\xff") # Clean a garbage
+      @sp.should_receive(:flush_input)  # Clean a garbage
       @sp.should_receive(:read).with(2).and_return("\x1\x3")
       @sp.should_receive(:read).with(1).and_return("\x2")
       @sp.should_receive(:read).with(4).and_return("\xff\xff\xb9\xf4")

--- a/spec/rtu_client_spec.rb
+++ b/spec/rtu_client_spec.rb
@@ -7,7 +7,7 @@ describe ModBus::RTUClient do
     SerialPort.should_receive(:new).with("/dev/port1", 9600, 8, 1, 0).and_return(@sp)    
     @sp.stub!(:read_timeout=)
     @sp.should_receive(:flow_control=).with(SerialPort::NONE)
-    @sp.stub!(:read_nonblock)
+    @sp.stub!(:flush_input)
 
     @cl = ModBus::RTUClient.new("/dev/port1", 9600, :data_bits => 8, :stop_bits => 1, :parity => SerialPort::NONE)
     @slave = @cl.with_slave(1)
@@ -47,15 +47,6 @@ describe ModBus::RTUClient do
       cl.data_bits.should == 8
       cl.stop_bits.should == 1
       cl.parity.should == SerialPort::NONE
-    end
-  end
-
-  unless RUBY_PLATFORM.include? "mingw"
-    it 'should ignore EOFError during clearing the buffer' do
-      @sp.should_receive(:read_nonblock).and_raise(EOFError)
-
-      request = stab_valid_request
-      lambda { @slave.query(request)}.should_not raise_error(EOFError)
     end
   end
 

--- a/spec/rtu_via_tcp_client_spec.rb
+++ b/spec/rtu_via_tcp_client_spec.rb
@@ -7,7 +7,7 @@ describe ModBus::RTUViaTCPClient do
       @sock = mock('Socked')
       TCPSocket.should_receive(:new).with("127.0.0.1", 10002).and_return(@sock)    
       @sock.stub!(:read_timeout=)
-      @sock.stub!(:read_nonblock)
+      @sock.stub!(:flush_input)
       
       @cl = ModBus::RTUViaTCPClient.new("127.0.0.1")
       @slave = @cl.with_slave(1)


### PR DESCRIPTION
This fix avoids calling readpartial on Windows platform which is very slow. Plus the code becomes a little cleaner. 