### PR TITLE
Validate unit identifier

### DIFF
--- a/lib/rmodbus/tcp_server.rb
+++ b/lib/rmodbus/tcp_server.rb
@@ -42,16 +42,16 @@ module ModBus
 
     # Serve requests
     # @param [TCPSocket] io socket
-		def serve(io)
-			while not stopped?
+    def serve(io)
+      while not stopped?
         header = io.read(7)
         tx_id = header[0,2]
         proto_id = header[2,2]
         len = header[4,2].unpack('n')[0]
         unit_id = header.getbyte(6)
-				if proto_id == "\x00\x00"
+        if proto_id == "\x00\x00"
           req = io.read(len - 1)
-				  if unit_id == @uid || unit_id == 0
+          if unit_id == @uid || unit_id == 0
             log "Server RX (#{req.size} bytes): #{logging_bytes(req)}"
 
             pdu = exec_req(req, @coils, @discrete_inputs, @holding_registers, @input_registers)
@@ -63,7 +63,7 @@ module ModBus
             log "Ignored server RX (invalid unit ID #{unit_id}, #{req.size} bytes): #{logging_bytes(req)}"
           end
         end
-			end
-		end
+      end
+    end
 	end
 end

--- a/lib/rmodbus/tcp_server.rb
+++ b/lib/rmodbus/tcp_server.rb
@@ -49,15 +49,19 @@ module ModBus
         proto_id = header[2,2]
         len = header[4,2].unpack('n')[0]
         unit_id = header.getbyte(6)
-				if proto_id == "\x00\x00" or unit_id == @uid
+				if proto_id == "\x00\x00"
           req = io.read(len - 1)
-          log "Server RX (#{req.size} bytes): #{logging_bytes(req)}"
+				  if unit_id == @uid || unit_id == 0
+            log "Server RX (#{req.size} bytes): #{logging_bytes(req)}"
 
-          pdu = exec_req(req, @coils, @discrete_inputs, @holding_registers, @input_registers)
+            pdu = exec_req(req, @coils, @discrete_inputs, @holding_registers, @input_registers)
 
-          resp = tx_id + "\0\0" + (pdu.size + 1).to_word + @uid.chr + pdu
-          log "Server TX (#{resp.size} bytes): #{logging_bytes(resp)}"
-          io.write resp
+            resp = tx_id + "\0\0" + (pdu.size + 1).to_word + @uid.chr + pdu
+            log "Server TX (#{resp.size} bytes): #{logging_bytes(resp)}"
+            io.write resp
+          else
+            log "Ignored server RX (invalid unit ID #{unit_id}, #{req.size} bytes): #{logging_bytes(req)}"
+          end
         end
 			end
 		end


### PR DESCRIPTION
I've been doing some work with MODBUS and stumbled upon this gem.  Very helpful -- thank you!

I've read the [documentation for MODBUS TCP/IP](http://www.modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf) several times and can't seem to determine definitively how/when the unit identifier is supposed to be used.  It seems to indicate in some situations it must be validated, and in others it need not be.  In `rmodbus`, it appears as if the _intent_ was to validate the unit identifier when using TCP/IP, however that functionality and the corresponding unit test were disabled.  I've fixed this.  In doing so I also had to clean up some of the header parsing and added new tests.

If it is correct to validate the unit identifier, right now this code simply does not respond.  It isn't clear to me what the best/desired behavior is -- the old unit test seemed to be expecting a `ModBus::Errors::ModBusException` but it isn't clear why.

If any of this is wrong, I'd love to learn why :smile: 